### PR TITLE
Use database wizard on questionnaire page

### DIFF
--- a/app/questionnaire/page.tsx
+++ b/app/questionnaire/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import QuestionnaireWizard from "@/components/questionnaire/wizard"
+import QuestionnaireWizardWithDatabase from "@/components/questionnaire/wizard-with-database"
 
 export const metadata: Metadata = {
   title: "Find Your Space | RentSmallSpace.com",
@@ -10,7 +10,7 @@ export default function QuestionnairePage() {
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-white py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
-        <QuestionnaireWizard />
+        <QuestionnaireWizardWithDatabase />
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- replace questionnaire wizard in page with database-backed version

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d99d01c948333ad590fa5ca500cc5